### PR TITLE
Fix url in the example request in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mvn spring-boot:run
 To parse a resume need to follow this cURL request
 
 ```Shell
-curl -XPOST -F file=@resume.pdf http://localhost:8080/resume/parse
+curl -XPOST -F file=@resume.pdf http://localhost:8080/parse/resume
 ```
 #### Response
 ```


### PR DESCRIPTION
The route mentioned in readme file `/resume/parse` does not exist and the correct route is `/parse/resume`. This pull request fixes this error.